### PR TITLE
DLS/HTTP Response 403

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -53,3 +53,4 @@ when@test:
                 cost: 4 # Lowest possible value for bcrypt
                 time_cost: 3 # Lowest possible value for argon
                 memory_cost: 10 # Lowest possible value for argon
+    access_denied_url: /acces-refuse

--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/erreur', name: '_erreur')]
+class ErrorController extends AbstractController
+{
+    #[Route('/acces-refuse', name: '_acces-refuse')]
+    public function accessDenied(): Response
+    {
+        return $this->render('erreur/acces_refuse.html.twig')->setStatusCode(Response::HTTP_FORBIDDEN);
+    }
+}

--- a/templates/erreur/acces_refuse.html.twig
+++ b/templates/erreur/acces_refuse.html.twig
@@ -1,0 +1,8 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Accès refusé{% endblock %}
+
+{% block body %}
+    <h1>Accès refusé</h1>
+    <p>Vous n'êtes pas autorisé à accéder à cette page.</p>
+{% endblock %}


### PR DESCRIPTION
Création controller et twig pour redirection en cas d'accès refusé (statuscode 403). Màj security.yaml.
Appel à la méthode : return $this->forward('App\Controller\ErrorController::accessDenied', []);